### PR TITLE
feat: EKM extraction logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,9 @@ mod attestation;
 pub mod client;
 pub mod server;
 
-const MAGIC_BYTES: [u8; 6] = *b"TEETLS";
+const MAGIC_BYTES: &[u8; 6] = b"TEETLS";
+const EKM_LABEL: &[u8; 21] = b"EXPORTER-pluto-notary";
+const EKM_CONTEXT: &[u8; 3] = b"tee";
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR adds the [export_keying_material](https://docs.rs/rustls/latest/rustls/server/struct.ServerConnection.html#method.export_keying_material) logic for the client and server.